### PR TITLE
edit layer.py add missing relu in ResBlock

### DIFF
--- a/layer.py
+++ b/layer.py
@@ -84,7 +84,7 @@ class ResBlock(nn.Module):
         self.resblk = nn.Sequential(*layers)
 
     def forward(self, x):
-        return x + self.resblk(x)
+        return torch.relu(x + self.resblk(x))
 
 
 class PixelUnshuffle(nn.Module):


### PR DESCRIPTION
Deep Residual Learning for Image Recognition 논문에서 Residual Block type 1(ResNet18, ResNet34)는 x+f(x) 이후 ReLu를 해주는 것으로 표기되어있어서 ResBlock 클래스의 forward 메소드 부분을 수정했습니다.  

https://arxiv.org/pdf/1512.03385.pdf